### PR TITLE
Add warning banner to TileMill docs

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -5,5 +5,8 @@ section: tilemill-docs
 
 <div class='prose pad2 doc round fill-white keyline-all'>
   <h1 id='{{page.title|downcase|replace:' ', '_'}}'>{{page.title}}</h1>
+  <div class='fill-yellow pad1y pad2x medium icon alert space-bottom round'>
+    TileMill is no longer in active development. For our most up-to-date map design tool, check out <a href='https://mapbox.com/mapbox-studio'>Mapbox Studio</a>.
+  </div>
   {{content}}
 </div>


### PR DESCRIPTION
Adds a banner to all TileMill docs pages with a link to Mapbox Studio.

![screen shot 2015-04-07 at 12 55 49 pm](https://cloud.githubusercontent.com/assets/2523165/7032162/c36be0b6-dd25-11e4-9058-d746a6a23599.png)

cc @alianthes @katydecorah 