### PR TITLE
Update warning banner to include link to Mapbox Studio Classic

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -6,7 +6,7 @@ section: tilemill-docs
 <div class='prose pad2 doc round fill-white keyline-all'>
   <h1 id='{{page.title|downcase|replace:' ', '_'}}'>{{page.title}}</h1>
   <div class='fill-yellow pad1y pad2x medium icon alert space-bottom round'>
-    TileMill is no longer in active development. For our most up-to-date map design tool, check out <a href='https://mapbox.com/mapbox-studio-classic'>Mapbox Studio Classic</a>.
+    TileMill is no longer in active development. For our most up-to-date desktop map design tool, check out <a href='https://mapbox.com/mapbox-studio-classic'>Mapbox Studio Classic</a>.
   </div>
   {{content}}
 </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -6,7 +6,7 @@ section: tilemill-docs
 <div class='prose pad2 doc round fill-white keyline-all'>
   <h1 id='{{page.title|downcase|replace:' ', '_'}}'>{{page.title}}</h1>
   <div class='fill-yellow pad1y pad2x medium icon alert space-bottom round'>
-    TileMill is no longer in active development. For our most up-to-date map design tool, check out <a href='https://mapbox.com/mapbox-studio'>Mapbox Studio</a>.
+    TileMill is no longer in active development. For our most up-to-date map design tool, check out <a href='https://mapbox.com/mapbox-studio-classic'>Mapbox Studio Classic</a>.
   </div>
   {{content}}
 </div>


### PR DESCRIPTION
It was linking to Mapbox Studio, now links to Mapbox Studio Classic. cc @katydecorah 