### PR TITLE
Upgrade to carto 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "JSV": "4.0.x",
     "backbone-dirty": "~1.1.3",
     "bones": "https://github.com/developmentseed/bones/tarball/1.3",
-    "carto": "~0.15.3",
+    "carto": "~0.16.0",
     "chrono": "~1.0.1",
     "generic-pool": "~2.4.1",
     "glob": "~7.0.0",


### PR DESCRIPTION
`npm test` passes, and @springmeyer did testing in mapbox/carto#440