### PR TITLE
Add YAML support

### DIFF
--- a/models/Project.server.bones
+++ b/models/Project.server.bones
@@ -183,11 +183,18 @@ function loadProject(model, callback) {
         read(path.join(modelPath, 'project.mml'), function(err, stat) {
             if (! err) return cb(err, stat);
 
-            // If `project.mml` is missing fallback to `PROJECTNAME.mml`
-            read(path.join(modelPath, model.id + '.mml'), cb);
+            // If `project.mml` is missing, fall back to `project.yml`, `PROJECTNAME.mml`, `PROJECTNAME.yml`
+            read(path.join(modelPath, 'project.yml'), function(err, stat) {
+                if (! err) return cb(err, stat);
+                read(path.join(modelPath, model.id + '.mml'), function(err, stat) {
+                    if (! err) return cb(err, stat);
+                    read(path.join(modelPath, model.id + '.yml'), cb);
+                });
+            });
         });
     },
     function(err, file) {
+        // projectName is only used for error messages
         var projectName = path.join(modelPath, 'project.mml');
         if (err) return callback(new Error.HTTP('Project does not exist: "' + projectName + '"', 404));
         try {
@@ -296,7 +303,9 @@ function loadProjectAll(model, callback) {
                 var modelPath = path.join(basepath, file.basename);
                 return ((file.isDirectory() && file.basename[0] !== '.')
                          && (existsSync(path.join(modelPath, 'project.mml')) ||
-                             existsSync(path.join(modelPath, file.basename + '.mml'))));
+                             existsSync(path.join(modelPath, 'project.yml')) ||
+                             existsSync(path.join(modelPath, file.basename + '.mml')) ||
+                             existsSync(path.join(modelPath, file.basename + '.yml'))));
             })
             .each(function(file) { loadProject({id:file.basename}, group()) });
     },

--- a/models/Project.server.bones
+++ b/models/Project.server.bones
@@ -7,6 +7,7 @@ var mkdirp = require('../lib/fsutil.js').mkdirp;
 var rm = require('../lib/fsutil.js').rm;
 var carto = require('carto');
 var mapnik = require('mapnik');
+var yaml = require('js-yaml');
 if (mapnik.register_default_fonts) mapnik.register_default_fonts();
 if (mapnik.register_system_fonts) mapnik.register_system_fonts();
 if (mapnik.register_default_input_plugins) mapnik.register_default_input_plugins();
@@ -190,7 +191,7 @@ function loadProject(model, callback) {
         var projectName = path.join(modelPath, 'project.mml');
         if (err) return callback(new Error.HTTP('Project does not exist: "' + projectName + '"', 404));
         try {
-            object = _(object).extend(JSON.parse(file.data));
+            object = _(object).extend(yaml.safeLoad(file.data));
         } catch(err) {
             var err_message = 'Could not open project.mml file for "' + model.id + '". Error was: \n\n"' + err.message + '"\n\n(in ' + projectName + ')';
             return callback(new Error(err_message));

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chrono": "~1.0.1",
     "generic-pool": "~2.4.1",
     "glob": "~7.0.0",
+    "js-yaml": "^3.4.6",
     "mapbox-upload": "~4.2.2",
     "mapnik": "~3.5.13",
     "mbtiles": "~0.8.2",


### PR DESCRIPTION
* Lets `project.mml` and `PROJECTNAME.mml` be read as YAML
* Checks `project.yml` and `PROJECTNAME.yml` in addition to the above two filenames

This is a "soft" conversion to YAML: It only supports it on input, and it will still write `project.mml` as JSON.

It doesn't depend on #2551, but they are related as anyone using YAML files will need Carto 0.16.0 on the server to convert to XML